### PR TITLE
Revert "Bypass build cache in vercel"

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,1 @@
 NEXT_PUBLIC_GLEAN_APP_BASE_URL=https://glean.io
-# Had issues with new nav items not appearing without this
-VERCEL_FORCE_NO_BUILD_CACHE=1


### PR DESCRIPTION
Reverts glean-io/documentation#16

- Correction - I think this has to be an environment variable because of where these .env variables get picked up (for the next build but not for vercel)