### PR TITLE
Getting Started docs improvements.

### DIFF
--- a/pages/docs/getting-started.mdx
+++ b/pages/docs/getting-started.mdx
@@ -4,6 +4,7 @@ import { Callout } from "nextra-theme-docs";
 
 Glean is an interactive data exploration tool that enables anyone in your organization to discover actionable insights. If you have feedback about the product or this documentation, please reach out to [product@glean.io](mailto:product@glean.io).
 
+<br />
 <div>
   <div style={{ position: "relative", paddingBottom: "62.5%", height: 0 }}>
     <iframe
@@ -33,13 +34,11 @@ Glean is an interactive data exploration tool that enables anyone in your organi
 
 ### 1. Define your Data Model
 
-Your data models define metrics and filters upfront so you can analyze data without writing writing code everytime. See the [Data Modeling Overview](/docs/data-modeling/Data-Models-Overview.md)
+Your data models define metrics and filters upfront so you can analyze data without writing writing code everytime. See the [Data Modeling Overview](/docs/data-modeling/Data-Models-Overview.md).
 
 ### 2. Analyze and Explore
 
-Glean automatically sets up an intuitive data explorer for each data model.
-
-You can save views of the data that are important to your organization.
+Glean automatically sets up an intuitive data explorer for each data model. You can save views of the data that are important to your organization.
 
 ### 3. Share
 


### PR DESCRIPTION
Makes small copy-level improvements to the Getting Started page. Namely:
1. Adding spacing between the first paragraph and the demo video.
2. Adding a missing period in the `Define your Data Model` section.
3. Removing gratuitous spacing in the `Analyze and Explore` section.