### PR TITLE
Fix copy formatting in Data Models pages.

### DIFF
--- a/pages/docs/data-modeling/add-data-model.mdx
+++ b/pages/docs/data-modeling/add-data-model.mdx
@@ -29,11 +29,11 @@ When possible, you should try to modify or extend an existing data model instead
   underlying data query that will run as you explore data.
 </Callout>
 
-1. From your [project homepage](https://glean.io/app/), click `New Model`
-2. Select the data connection you'd like to use or "Uploads" if you want to use [a file from your computer](/docs/data-modeling/query-data-files)
-3. Select either an existing table or click `SQL Editor` to use a custom query
-4. Click `Build Model` to create the initial data model (All date fields and a row count metric are added by default)
-5. Edit the name of the data model at the top of the page
-6. Add additional metrics and attributes by clicking `Add metric` and `Add Attribute` next to the name of the field
-7. Create a SQL based custom metric by clicking `+ Add Custom Metric` (see [Metrics](/data-modeling/metrics) for more details)
-8. Click `Save Model` then click `Open in Explore` to start exploring the data
+1. From your [project homepage](https://glean.io/app/), click `New Model`.
+2. Select the data connection you'd like to use or `Uploads` if you want to use [a file from your computer](/docs/data-modeling/query-data-files).
+3. Select either an existing table or click `SQL Editor` to use a custom query.
+4. Click `Build Model` to create the initial data model (all date fields and a row count metric are added by default).
+5. Edit the name of the data model at the top of the page.
+6. Add additional metrics and attributes by clicking `Add metric` and `Add Attribute` next to the name of the field.
+7. Create a SQL based custom metric by clicking `+ Add Custom Metric` (see [Metrics](/data-modeling/metrics) for more details).
+8. Click `Save Model` then click `Open in Explore` to start exploring the data.

--- a/pages/docs/data-modeling/best-practices.mdx
+++ b/pages/docs/data-modeling/best-practices.mdx
@@ -27,7 +27,7 @@ If it's hard to describe what each row represents, it's possible you're not pick
   it won't accidentially get used " row count - dont use".
 </Callout>
 
-## Denormalize your Data
+## Denormalize your data
 
 Once you pick which domain you want to model, it's a good idea to pull in relevant information about that domain by denormalizing the data.
 

--- a/pages/docs/data-modeling/caching.mdx
+++ b/pages/docs/data-modeling/caching.mdx
@@ -22,10 +22,10 @@ If you set this to 1, then the cache will effectively be disabled (data will onl
 
 ## Changing caching Time To Live (TTL)
 
-1. Go to the [data models page](https://glean.io/app/p/data-models)
+1. Go to the [data models page](https://glean.io/app/p/data-models).
 2. Click the edit button for the data model you want to update.
 3. Open `⚙️ Advanced Settings` via the `...` menu in the top right.
-4. Change the `Cache TTL`
+4. Change the `Cache TTL`.
 
 ## Manually clearing the cache
 
@@ -40,7 +40,7 @@ glean cache clear m:MODEL_ID
 
 Alternatively, you can reset the model's cache in the UI:
 
-1. Go to the [data models page](https://glean.io/app/p/data-models)
+1. Go to the [data models page](https://glean.io/app/p/data-models).
 2. Click the edit button for the data model you want to update.
 3. Open `⚙️ Advanced Settings` via the `...` menu in the top right.
 4. Click the `remove all cached queries` button beside the TTL input.

--- a/pages/docs/data-modeling/metrics.mdx
+++ b/pages/docs/data-modeling/metrics.mdx
@@ -6,36 +6,38 @@ Counts of events, revenues and cycle times are good examples of metrics you may 
 
 You will setup and update metrics from the [Add Data Model](/docs/data-modeling/add-data-model) workflow.
 
-## Types of Metrics
+## Types of metrics
 
-| Name           | Input Column Type        | Description                                                                     |
-| -------------- | ------------------------ | ------------------------------------------------------------------------------- |
-| row count      | No input column required | Count of rows                                                                   |
-| custom metric  | No input column required | A SQL-based custom aggregation, see Custom SQL Metrics for more details         |
-| count          | String or Numeric        | SQL count() over a field - counts the number of times the field is not NULL     |
-| count distinct | String or Numeric        | SQL count(distinct ) - counts the number of unique, non-null values in a column |
-| min            | Numeric                  | SQL min() - finds the minimum value of a column                                 |
-| max            | Numeric                  | SQL max() - finds the maximum value of a column                                 |
-| avg            | Numeric                  | SQL avg() - finds the arithmetic mean of a column                               |
+| Name           | Input Column Type        | Description                                                                                                                |
+| -------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| row count      | No input column required | Count of rows.                                                                                                             |
+| custom metric  | No input column required | A SQL-based custom aggregation. See [Custom SQL Metrics](/docs/data-modeling/metrics#custom-sql-metrics) for more details. |
+| count          | String or Numeric        | SQL `COUNT()`. Counts the number of non-null values in a column.                                                           |
+| count distinct | String or Numeric        | SQL `COUNT(DISTINCT)`. Counts the number of unique, non-null values in a column.                                           |
+| min            | Numeric                  | SQL `MIN()`. Finds the minimum value of a column.                                                                          |
+| max            | Numeric                  | SQL `MAX()`. Finds the maximum value of a column.                                                                          |
+| avg            | Numeric                  | SQL `AVG()`. Finds the arithmetic mean of a column.                                                                        |
 
 ## The row count metric
 
-The row count metric is added by default to a data model and can't be removed. This is intentional - see the best practices for defining this metric in the [Data Modeling Best Practices](/docs/data-modeling/best-practices)
+The row count metric is added by default to a data model and can't be removed. This is intentional - see the best practices for defining this metric in the [Data Modeling Best Practices](/docs/data-modeling/best-practices).
 
-## Column Aggregations
+## Column aggregations
 
 The simplest type of metric. See table above for which functions you can run on specific metrics.
 
 To add a column aggregating metric:
 
-1. Go to the [Add Data Model](/docs/data-modeling-add-data-model) workflow by creating a new data model or editing an existing model
-2. In the list of fields, click `Add metric` next to the name of the field you'd like to aggregate
+1. Go to the [Add Data Model](/docs/data-modeling/add-data-model) workflow by creating a new data model or editing an existing model.
+2. In the list of fields, click `Add metric` next to the name of the field you'd like to aggregate.
 3. Click on the new item in the Metric list to expand the and select the aggregation type.
 
-## Custom SQL Metrics
+## Custom SQL metrics
 
-Custom SQL metrics allow you to have more involved custom aggregations in Glean like weighted averages or proportions and other formulas. You can define a custom metric as any [aggregating function](https://www.datacamp.com/community/tutorials/aggregate-functions-sql) that results in a numeric value. To add a custom metric:
+Custom SQL metrics allow you to have more involved custom aggregations in Glean like weighted averages or proportions and other formulas. You can define a custom metric as any [aggregating function](https://www.datacamp.com/community/tutorials/aggregate-functions-sql) that results in a numeric value.
 
-1. Go to the [Add Data Model](/docs/data-modeling/add-data-model) workflow by creating a new data model or editing an existing model
-2. Under the Metrics section click the `+ Add Custom Metric` button
-3. Enter your aggregation and click the 🔄 button to test the SQL
+To add a custom metric:
+
+1. Go to the [Add Data Model](/docs/data-modeling/add-data-model) workflow by creating a new data model or editing an existing model.
+2. Under the Metrics section click the `+ Add Custom Metric` button.
+3. Enter your aggregation and click the 🔄 button to test the SQL.

--- a/pages/docs/data-modeling/query-data-files.mdx
+++ b/pages/docs/data-modeling/query-data-files.mdx
@@ -3,7 +3,7 @@
 Glean can directly use CSVs and other common data files for small or adhoc
 analysis, without needing to set up a traditional database.
 
-## Uploading Files
+## Uploading files
 
 From [the model builder page](https://glean.io/app/mb),
 select "Uploads" as the data connection. You can then either click the "Upload"
@@ -13,7 +13,7 @@ the file to Glean and make it available as if it were a table in a databse.
 You can update the contents of an existing file by uploading or dragging in a
 new version with the same name.
 
-### Supported Files
+### Supported files
 
 Glean currently supports the following formats:
 
@@ -25,7 +25,7 @@ Glean currently supports the following formats:
 
 Glean enforces a max size of 50 MB for uploaded files.
 
-## Writing SQL for Uploaded Files
+## Writing SQL for uploaded files
 
 Glean uses [DuckDB](https://duckdb.org/) as the SQL-engine for uploaded files.
 


### PR DESCRIPTION
This fixes formatting in `Data Models` pages. Namely:
1. Using sentence casing for all non-title text.
2. Ending numbered list items with periods.
3. Improving spacing and other copy formatting where appropriate.