### PR TITLE
Fix copy formatting in Database Connections pages.

### DIFF
--- a/pages/docs/database-connections/_template.mdx
+++ b/pages/docs/database-connections/_template.mdx
@@ -2,29 +2,29 @@
 
 > This is a template for how we describe each database.
 > This section could be the first (and sometimes only) exposure that a user has to
-> our documentation - they just want to see how to setup Glean!
-> So we should make it clear how to accomplish this task and what to do next
+> our documentation - they just want to see how to set up Glean!
+> So we should make it clear how to accomplish this task and what to do next.
 
 In the overview section, we should give Glean's take on how we think about this database in the broader Modern Data Stack landscape.
 
-There is then a "how to get setup" section:
+There is then a "How to get setup" section:
 
 ### How to get set up
 
-1. usually step one is get an account, mention if it's free or if they have to talk to a sales person.
-2. Configure credentials in the other system
-3. setup a connection in Glean
+1. Usually step one is get an account, mention if it's free or if they have to talk to a sales person.
+2. Configure credentials in the other system.
+3. Set up a connection in Glean.
 
 ## Create a user in XYZ system
 
-Explain how to setup a user for Glean, feel free to link to their documentation. Scripts that setup permissions can be helpful
+Explain how to setup a user for Glean, feel free to link to their documentation. Scripts that setup permissions can be helpful.
 
 ## Create an XYZ database connection in Glean
 
-1. First, goto your [Glean settings](https://glean.io/app/p/settings#database_connections) page from the project dropdown
-2. Click `+ New Database Connection` and fill out the fields below
+1. First, go to your [Glean settings](https://glean.io/app/p/settings#database_connections) page from the project dropdown.
+2. Click `+ New Database Connection` and fill out the fields below.
 
 ### Settings
 
-- **Username:** the username
-- **Password:** the password
+- **Username:** The username.
+- **Password:** The password.

--- a/pages/docs/database-connections/athena.mdx
+++ b/pages/docs/database-connections/athena.mdx
@@ -49,9 +49,9 @@ Glean's caching. Amazon has a few good articles on
 2.  Create an appropriate IAM policy for Athena access. Your service account
     needs access to three AWS services:
 
-    - `Glue` manages metadata required to map query-referenced resources to data
+    - `Glue` for managing metadata required to map query-referenced resources to data
       stored in s3.
-    - `S3` to access the underlying data that you want to query in addition to
+    - `S3` for accessing the underlying data that you want to query in addition to
       storing results of your queries.
     - `Athena` for managing and running queries.
 
@@ -81,30 +81,31 @@ Glean's caching. Amazon has a few good articles on
     means, assigning the policy to a role, adding the role to a group's
     permissions and adding the user to that group.
 4.  [Generate an access key](https://aws.amazon.com/premiumsupport/knowledge-center/create-access-key/)
-    for your IAM user
+    for your IAM user.
 
 ## Create an Athena database connection in Glean
 
-1. First, goto your
+1. First, go to your
    [Glean settings](https://glean.io/app/p/settings#database_connections) page
-   from the project dropdown
-2. Click `+ New Database Connection` and fill out the fields below
+   from the project dropdown.
+2. Click `+ New Database Connection` and fill out the fields below.
 
 ### Settings
 
 <Callout>
-  We highly recommend specifying a schema (ie. Athena database) to make querying
-  metadata and getting lists of tables faster in Glean during development.
+  We highly recommend specifying a schema (i.e. Athena database) to make
+  querying metadata and getting lists of tables faster in Glean during
+  development.
 </Callout>
 
-- **AWS Region**: the aws region to use to query data
-- **port**: _optional_
-- **schema**: also called databases in Athena documentation. Listing tables and
+- **AWS Region:** The AWS region to use to query data.
+- **Port:** _(optional)_ The port to connect to.
+- **Schema:** _(optional, but highly recommended)_ Also called a "database" in Athena documentation. Listing tables and
   testing connections can take a long time in Athena if you don't specify a
   schema.
-- **S3 staging directory**: the S3 path where Athena will store query results.
-- **AWS access key ID**: the IAM user's access key
-- **AWS secret access key**: the IAM user's scret access key, generated in step
-  4 above
-- **Query parameters**: dditional database connection parameters in the format
-  ` workGroup=value&param=value`
+- **S3 Staging Directory:** The S3 path where Athena will store query results.
+- **AWS Access Key ID:** The IAM user's access key.
+- **AWS Secret Access Key:** The IAM user's scret access key, generated in step
+  4 [above](/docs/database-connections/athena#create-an-aws-iam-user-for-glean).
+- **Query Parameters:** _(optional)_ Additional database connection parameters in the format
+  ` workGroup=value&param=value`.

--- a/pages/docs/database-connections/bigquery.mdx
+++ b/pages/docs/database-connections/bigquery.mdx
@@ -14,12 +14,12 @@ If you have relatively small data and are very early, using something
 lightweight like Postgres or uploading csvs or parquet files to our DuckDB
 integration could also be good options.
 
-### How to get set up:
+### How to get set up
 
 1. [Sign up for free GCP / BigQuery](https://cloud.google.com/bigquery) account
-   if you don't have one
-2. Set up a Service User Account in Google Cloud
-3. Set up a database connection in Glean
+   if you don't have one.
+2. Set up a Service User Account in Google Cloud.
+3. Set up a database connection in Glean.
 
 ## Create a BigQuery service account
 
@@ -29,9 +29,9 @@ account JSON key file into this field. See the
 [Google documentation on authenticating with service accounts](https://cloud.google.com/bigquery/docs/authentication/service-account-file)
 
 1. Create a service account in GCP by going to
-   [IAM > service accounts](https://console.cloud.google.com/iam-admin/serviceaccounts)
-2. Select `+ Create Service Account` from the top of the page
-3. When prompted you will need to add four IAM roles below
+   [IAM > service accounts](https://console.cloud.google.com/iam-admin/serviceaccounts).
+2. Select `+ Create Service Account` from the top of the page.
+3. When prompted you will need to add four IAM roles below:
 
    - `BigQuery User`
    - `BigQuery Data Viewer`
@@ -48,20 +48,14 @@ account JSON key file into this field. See the
 
 1. First, go to your
    [Glean settings](https://glean.io/app/p/settings#database_connections) page
-   from the project dropdown
-2. Click `+ New Database Connection` and fill out the fields below
+   from the project dropdown.
+2. Click `+ New Database Connection` and fill out the fields below.
 
 ### Settings
 
-- **Connection name**: a name for this database connection. If you use DataOps,
+- **Connection Name:** A name for this database connection. If you use [DataOps](/docs/data-ops),
   you can use the connection name to refer to this database.
-- **Project name**: the GCP project. This is optional since it's usually also
+- **Project Name:** _(optional)_ The GCP project. This is optional since it's usually also
   included in the below key file.
-- **JSON key file**: the entire contents of the JSON key file for the service
-  account needs to be copy and pasted into this field.
-
-<Callout type="info">
-  **"JSON key file"**- BigQuery service accounts use a JSON file as a
-  credential. You will have to copy and paste the entire contents of this JSON
-  file into the JSON key file field.
-</Callout>
+- **JSON Key:** BigQuery service accounts use a JSON file as a credential. The entire contents
+  of this file needs to be copied and pasted into this field.

--- a/pages/docs/database-connections/clickhouse.mdx
+++ b/pages/docs/database-connections/clickhouse.mdx
@@ -18,18 +18,18 @@ You might want to use ClickHouse in scenarios that involve querying and processi
 
 If you have relatively small data or are very early, using something lightweight like Postgres or uploading csvs or parquet files to our DuckDB integration could also be good options.
 
-### How to get set up:
+### How to get set up
 
 1. Set up a ClickHouse database, either by hosting it on your own infrastructure or signing up for [ClickHouse Cloud](https://clickhouse.com/).
 2. Set up a username and password for usage by Glean.
-3. In Glean, go to your [project settings](https://glean.io/app/p/settings#database_connections) page from the project dropdown and click `+ New Database Connection`
+3. In Glean, go to your [project settings](https://glean.io/app/p/settings#database_connections) page from the project dropdown and click `+ New Database Connection`.
 4. Change the datatabse type to "ClickHouse" and fill out the connection settings as described below.
 
 ### Settings
 
 - **Connection Name:** A nickname for your connection. Not used to connect to your database.
-- **Host:** the address of your Clickhouse database
-- **Port:** the port used for secure native connections to your ClickHouse database. This is usually `9440`.
-- **Username:** the username
-- **Password:** the password
-- **Database:** the name of the database to read from
+- **Host:** The address of your Clickhouse database.
+- **Port:** The port used for secure native connections to your ClickHouse database. This is usually `9440`.
+- **Username:** The username.
+- **Password:** The password.
+- **Database:** The name of the database to read from.

--- a/pages/docs/database-connections/duckdb.mdx
+++ b/pages/docs/database-connections/duckdb.mdx
@@ -19,7 +19,7 @@ to get their data into Glean without setting up any servers.** DuckDB is _not_
 a good choice if your dataset is large, or needs to be updated in realtime
 from an external system.
 
-### How to get setup
+### How to get set up
 
 Glean pre-configures a DuckDB connection for every project. You are already
 ready to start exploring data files in your Glean project.
@@ -30,8 +30,8 @@ more information.
 ### Organizing file groups
 
 If you have lots of uploaded files, it may be helpful to organize them into
-distinct groups. To do so, you can create a new data connection of the "DuckDB"
+distinct groups. To do so, you can create a new data connection of the `DuckDB`
 type.
 
-1. First, go to your [Glean settings](https://glean.io/app/p/settings#database_connections) page from the project dropdown
-2. Click `+ New Database Connection` and select "Uploaded Files (DuckDB)"
+1. First, go to your [Glean settings](https://glean.io/app/p/settings#database_connections) page from the project dropdown.
+2. Click `+ New Database Connection` and select `Uploaded Files (DuckDB)`.

--- a/pages/docs/database-connections/mysql.mdx
+++ b/pages/docs/database-connections/mysql.mdx
@@ -10,17 +10,17 @@ If you're starting off with a copy of your application database, it's likely you
 
 Long term, we'd recommend eventually moving your analytics data to a modern data warehouse (like BigQuery or Snowflake) to get the most out of Glean.
 
-### How to get setup
+### How to get set up
 
 1. If you're using MySQL because that's what your application's backend is based on, make sure you're on a read-replica so your analytics queries don't bog down your application database.
-2. [Create a read-only user for Glean to use](https://dev.mysql.com/doc/refman/8.0/en/create-user.html) and grant it the appropriate permissions
-3. Go to your [Glean settings](https://glean.io/app/p/settings#database_connections) page
-4. Click `+ New Database Connection` and fill out the fields below
+2. [Create a read-only user for Glean to use](https://dev.mysql.com/doc/refman/8.0/en/create-user.html) and grant it the appropriate permissions.
+3. Go to your [Glean settings](https://glean.io/app/p/settings#database_connections) page.
+4. Click `+ New Database Connection` and fill out the fields below.
 
 ### Settings
 
 - **Connection Name:** A nickname for your connection. Not used to connect to your database.
-- **Host:** the address of your MySQL database
-- **Username:** the username
-- **Password:** the password
+- **Host:** The address of your MySQL database.
+- **Username:** The username.
+- **Password:** The password.
 - **Database:** (_optional_) Specify a schema to limit which tables are available. Otherwise, Glean will make all accessible schemas and tables available

--- a/pages/docs/database-connections/postgresql.mdx
+++ b/pages/docs/database-connections/postgresql.mdx
@@ -6,7 +6,7 @@ Postgres is a great default choice for a database engine. It's a general purpose
 
 A benefit of its popularity is that there are easy and cheap providers of server-less instances, such as [Heroku](https://www.heroku.com/postgres) and [Neon](https://neon.tech). Additionally, there are other databases that are PostgreSQL compatible, such as Redshift, CockroachDB or Timescale. If you're using one of these databases, you can use our PostgreSQL connection type to connect to your database.
 
-If you're looking to get started an existing application database, querying your production database isn't ideal. We have an full write up on how to get started with a read replica:
+If you're looking to get started an existing application database, querying your production database isn't ideal. We have a full write up on how to get started with a read replica:
 
 - [Set up your data warehouse on Postgres in 30 minutes](https://glean.io/blog-posts/setup-your-data-warehouse-on-postgres-in-30-minutes)
 
@@ -14,20 +14,20 @@ If you're looking to get started an existing application database, querying your
 
 If you're starting off with a copy of your application database, there's a high chance you'll end up writing a query to join, transform, and filter data to prepare it for Glean as a denormalized table. It's worth checking which version of PostgreSQL you're on to see what transformation functions are available to you. Also, try to take advantage of indexes to keep queries fast.
 
-### How to get setup
+### How to get set up
 
-1. We recommend [creating a separate user for Glean](https://www.postgresql.org/docs/current/sql-createuser.html) to use in order to easily track usage and performance
-2. Grant the user the appropriate [roles](https://www.postgresql.org/docs/current/role-membership.html) needed to query your analytics data
-3. Set up a connection in Glean
-   1. First, go to your [Glean settings](https://glean.io/app/p/settings#database_connections) page from the project dropdown
-   2. Click `+ New Database Connection` and fill out the fields below
+1. We recommend [creating a separate user for Glean](https://www.postgresql.org/docs/current/sql-createuser.html) to use in order to easily track usage and performance.
+2. Grant the user the appropriate [roles](https://www.postgresql.org/docs/current/role-membership.html) needed to query your analytics data.
+3. Set up a connection in Glean:
+   1. First, go to your [Glean settings](https://glean.io/app/p/settings#database_connections) page from the project dropdown.
+   2. Click `+ New Database Connection` and fill out the fields below.
 
 ### Settings
 
 - **Connection Name:** A nickname for your connection. Not used to connect to your database.
-- **Host:** the address of your PostgreSQL database
-- **Port:** the open port of your Postgres host, it is often `5432`
-- **Username:** the username
-- **Password:** the password
-- **Database:** the name of the [database](https://www.postgresql.org/docs/current/ddl-schemas.html) to read from
-- **Schema:** (_optional_) Specify a schema to limit which tables are available. Otherwise, Glean will make all accessible schemas and tables available
+- **Host:** The address of your PostgreSQL database.
+- **Port:** The open port of your Postgres host, it is often `5432`.
+- **Username:** The username.
+- **Password:** The password.
+- **Database:** The name of the [database](https://www.postgresql.org/docs/current/ddl-schemas.html) to read from.
+- **Schema:** (_optional_) Specify a schema to limit which tables are available. Otherwise, Glean will make all accessible schemas and tables available.

--- a/pages/docs/database-connections/snowflake.mdx
+++ b/pages/docs/database-connections/snowflake.mdx
@@ -1,16 +1,24 @@
 # Snowflake
 
-If you have a lot of data and want to keep throwing it into a data warehouse, [Snowflake](https://www.snowflake.com) is a tried and tested solution. They continually push the boundary on sql and analytics features and their data sharing features between organizations are particularly strong for larger enterprisies.
+If you have a lot of data and want to keep throwing it into a data warehouse,
+[Snowflake](https://www.snowflake.com) is a tried and tested solution. They continue to push the
+boundaries of SQL and analytics features and their data sharing features between organizations are
+particularly strong for larger enterprises.
 
-About 50% of Glean's customers use Snowflake, if you're using AWS it is a good solution. If you don't have much data, using Postgres, Redshift or even DuckDB could be good options. Compared with Redshift, Snowflake has a more modern architecture with decoupled storage and compute that can scale to larger datasets more easily. This architecture is also much easier to manage with more flexibility on how much compute you use and fewer decisions on how you are going to lay out data. If Google Cloud is an option, you may also want to consider BigQuery as an alternative to Snowflake.
+About 50% of Glean's customers use Snowflake. If you're using AWS, Snowflake could be a good solution
+for you. If you don't have much data, using Postgres, Redshift, or even DuckDB could be good options
+too. Compared to Redshift, Snowflake has a more modern architecture with decoupled storage and compute
+that can scale to larger datasets more easily. This architecture is also much easier to manage with
+more flexibility over how much compute you use and fewer required decisions over how you lay out data.
+If Google Cloud is an option, you may also want to consider BigQuery as an alternative to Snowflake.
 
 ### How to get set up
 
-1. [Signup for a 30 day trial](https://signup.snowflake.com/) on Snowflake if you don't have an account
-2. Create a Snowflake user that Glean can use
-3. Set up a database connection in Glean
+1. [Sign up for a 30 day trial](https://signup.snowflake.com/) on Snowflake if you don't have an account.
+2. Create a Snowflake user that Glean can use.
+3. Set up a database connection in Glean.
 
-## Create a snowflake user
+## Create a Snowflake user
 
 You can run the following script. Make sure you fill out your database name, warehouse and a password in the script:
 
@@ -44,10 +52,10 @@ grant SELECT on future tables in database identifier($database_name) to role ide
 
 ### Settings
 
-- **Account**: [Your snowflake account](https://docs.snowflake.com/en/user-guide/connecting.html#your-snowflake-account-name) is provided by Snowflake and included in the start of the URL you use to login to Snowflake: snowflakecomputing.com
-- **User**: the Snowflake user, best practice is to have a service user specifically dedicated to Glean
-- **Password**: password used to login to Snowflake
-- **Database**: the Snowflake database to use, databases correspond with logical groupings of tables and views in Snowflake.
-- **Schema**: _optional_ if you provide a schema, we will limit listed tables in the model builder to this schema. If you need to limit permissions to a specific schema, you should do this with Snowflake permissions
-- **Warehouse**: the warehouse to use in Snowflake, warehouses correspond with compute resources.
-- **Role**: you must specify a role to be assumed when connecting from Glean. See snowflake's [roles](https://docs.snowflake.com/en/user-guide/security-access-control-overview.html#roles) documentation.
+- **Account:** [Your snowflake account identifier](https://docs.snowflake.com/en/user-guide/connecting.html#your-snowflake-account-identifier) is provided by Snowflake and included in the start of the URL you use to login to Snowflake: `<account_identifier>.snowflakecomputing.com`.
+- **User:** The Snowflake user. Best practice is to have a service user specifically dedicated to Glean.
+- **Password:** The password used to login to Snowflake.
+- **Database:** The Snowflake database to use. Databases correspond with logical groupings of tables and views in Snowflake.
+- **Schema:** _optional_ If you provide a schema, we will limit listed tables in the model builder to this schema. If you need to limit permissions to a specific schema, you should do this with Snowflake permissions.
+- **Warehouse:** The warehouse to use in Snowflake. Warehouses correspond with compute resources.
+- **Role:** You must specify a role to be assumed when connecting from Glean. See Snowflake's [roles](https://docs.snowflake.com/en/user-guide/security-access-control-overview.html#roles) documentation.


### PR DESCRIPTION
This normalizes how our Database Connections pages look (spacing, casing, list items, etc.) and tweaks copy where appropriate.