### PR TITLE
Fix copy formatting of Sharing Data Externally, Dashboards, Data Ops, Project Management, and Guides pages.

### DIFF
--- a/pages/docs/dashboards/filters.mdx
+++ b/pages/docs/dashboards/filters.mdx
@@ -7,7 +7,7 @@ blank to allow viewers to specify the filter only when they wish to.
 If there are specific charts or metrics that you would like the filters to ignore,
 you can check the "Ignore Dashboard Filters" setting in their configuration menu.
 
-## Editing Filters
+## Editing filters
 
 Filters can be added to the dashboard globally or to any section once there are
 charts or metrics which can be filtered. Click the `+` button then select the
@@ -18,21 +18,21 @@ You can click one a specific filter to edit its value. When editing a dashboard,
 any value set here will become the default value for the filter when viewers
 load the dashboard.
 
-## Filter Hierarchy
+## Filter hierarchy
 
 Filters exist at three levels. When filters from different levels overlap,
 they are prioritized as such:
 
-1. Section Filters
-2. Global Filters
-3. Saved View / Metric Filters
+1. Section filters
+2. Global filters
+3. Saved View / Metric filters
 
-![Filter Hierarchy](/dashboards/filter-hierarchy.png)
+![Filter hierarchy](/dashboards/filter-hierarchy.png)
 
 Note that filter rules do not combine together - a more permissive filter will
 take precedence and override less permissive ones.
 
-## Filter Synchronization
+## Filter synchronization
 
 Dashboard filters are automatically synchronized based on the underlying column name of your attributes. For example, if you have two data models, each with an attribute based on a `customer_id` field, you only need to
 add one filter to the dashboard, and it will filter both data

--- a/pages/docs/dashboards/metrics.mdx
+++ b/pages/docs/dashboards/metrics.mdx
@@ -1,5 +1,7 @@
 import { Callout } from "nextra-theme-docs";
 
+# Metrics
+
 Drag the number icon from the toolbar onto your dashboard to add a new metric
 to the dashboard. Hover over the metric and click the cog icon to edit it. Want to dig deeper into your data? Click on any metric tile when in view mode to see your metric in Explore.
 
@@ -13,7 +15,7 @@ to the dashboard. Hover over the metric and click the cog icon to edit it. Want 
 
 Metrics can be calculated as either **Simple Metrics** or **Relative Comparison** metrics. **Simple Metrics** calculate a value across _all_ data in a filtered range whereas **Relative Comparison** metrics calculate a value over specific periods of data so you can see a metric value for the last week, month, etc.
 
-### Simple Metrics
+### Simple metrics
 
 ![Setting up a simple metric](/dashboards/sparkline.gif)
 
@@ -21,7 +23,7 @@ Metrics can be calculated as either **Simple Metrics** or **Relative Comparison*
 
 **Sparkline:** Click the toggle to enable or disable a sparkline visualization of your metric. Select a date and granularity to go on the x axis of the sparkline. Although less commonly used, it's also possible to choose a number for the x axis.
 
-### Relative Metrics
+### Relative metrics
 
 <Callout type="info">
   **Calculating Relative Metrics** - Relative metrics display a metric value

--- a/pages/docs/dashboards/saved-views.mdx
+++ b/pages/docs/dashboards/saved-views.mdx
@@ -20,7 +20,7 @@ saved view will be used.
 
 ### Legend
 
-Change where the legend is placed. You can select "Inherit from Saved View" to match
+Change where the legend is placed. You can select `Inherit from Saved View` to match
 legend placement with the saved view.
 
 ### Axis Labels

--- a/pages/docs/dashboards/text.mdx
+++ b/pages/docs/dashboards/text.mdx
@@ -9,7 +9,7 @@ Drag the text icon from the toolbar onto your dashboard to add a new text block.
 You can style text using [markdown](https://commonmark.org/help/).
 Glean handles the exact styles to look good on every device.
 
-### Code Blocks
+### Code blocks
 
 You can use code blocks to place any important technical context directly in
 the dashboard. If you specify a programming language, Glean will apply

--- a/pages/docs/data-ops/cli.mdx
+++ b/pages/docs/data-ops/cli.mdx
@@ -8,7 +8,7 @@ The Glean CLI allows you to create Preview and Deploy Builds directly from your 
 
 ### 1. Create an Access Key
 
-To use the CLI with your Glean project, you need an **Access Key**. An Access Key is used by Glean to identify who you are and what resources you have access to. You should use a separate access key for each distinct user or service using the CLI.
+To use the CLI with your Glean project, you need an **Access Key**. An Access Key is used by Glean to identify who you are and what resources you have access to. You should use a separate Access Key for each distinct user or service using the CLI.
 
 1.  Go to the [`Settings`](https://glean.io/app/p/settings#access_keys) page using the link in the project dropdown
 2.  Click on `Access Keys`
@@ -28,17 +28,21 @@ $ mv ~/Downloads/glean_access_key.json ~/.glean/
 
 ### 2. Install Glean CLI
 
-1. Confirm [Python 3](https://www.python.org/downloads/) is installed
+1. Confirm [Python 3](https://www.python.org/downloads/) is installed:
+
    ```bash
    $ python3 --version
    ```
-2. Install Glean CLI into a virtual environment
+
+2. Install Glean CLI into a virtual environment:
+
    ```bash
    $ python3 -m venv venv
    $ source venv/bin/activate
    $ pip3 install glean-cli
    ```
-3. confirm sucessful installation
+
+3. Confirm sucessful installation:
 
 ```bash
 $ glean
@@ -72,13 +76,13 @@ $ glean explore database_connection_name table_name
 
 Since this creates a Preview only, the Data Model won't be persisted. However, a model configuration file will be saved in your local directory, so that you can later `glean deploy` that file.
 
-## Moving your access key
+## Moving your Access Key
 
-By default, the CLI expects your access key to be located at `~/.glean/glean_access_key.json`. You can override this by:
+By default, the CLI expects your Access Key to be located at `~/.glean/glean_access_key.json`. You can override this by:
 
 - Setting the `GLEAN_CREDENTIALS_FILEPATH` environment variable to a different filepath
 - Using the `--credentials-filepath` command-line option to use a different filepath
-- Setting the `GLEAN_PROJECT_ID`, `GLEAN_ACCESS_KEY_ID`, and `GLEAN_SECRET_ACCESS_KEY_TOKEN` environment variables to the respective values stored in your access key file.
+- Setting the `GLEAN_PROJECT_ID`, `GLEAN_ACCESS_KEY_ID`, and `GLEAN_SECRET_ACCESS_KEY_TOKEN` environment variables to the respective values stored in your Access Key file.
 
 ## Using environment variables
 
@@ -115,9 +119,9 @@ The CLI allows you to integrate Glean into your existing development and deploym
 7. Merge the Pull Request into your `main` git branch.
 8. Run `glean deploy --git-revision=main` to deploy your new Glean resources to your project.
 
-## Continuous Integration
+## Continuous integration
 
-You can invoke the glean CLI in a continuous integration system to automatically generate previews or deploy your project.
+You can invoke the Glean CLI in a continuous integration system to automatically generate previews or deploy your project.
 
 For example, if you use GitHub, the following GitHub action will generate a Build Preview of the local `glean` directory whenever you send a pull request:
 
@@ -144,7 +148,11 @@ jobs:
 If you provide a [GRN](./grns.mdx) as an argument, `glean pull` will restrict itself to only the specified resource and all resources it depends on. For example, `glean pull sv:the-sv-id` will retrieve the resource configuration for the specified saved view, plus any model(s) it depends on.
 
 <Callout type="warning">
-  When developing locally, you are not required to specify GRNs in Glean resource configuration files. However, when running `glean deploy`, GRNs are assigned based on the relative path from the working directory to the resource configuration file. Subsequent uses of `glean pull` should therefore be run from the same working directory.
+  When developing locally, you are not required to specify GRNs in Glean
+  resource configuration files. However, when running `glean deploy`, GRNs are
+  assigned based on the relative path from the working directory to the resource
+  configuration file. Subsequent uses of `glean pull` should therefore be run
+  from the same working directory.
 </Callout>
 
 Note that `glean pull` is a potentially destructive operation that will change files in your working directory. Make sure your `git status` is clean (no uncommitted changes in the working directory) before pulling resources.

--- a/pages/docs/data-ops/git-integration.mdx
+++ b/pages/docs/data-ops/git-integration.mdx
@@ -7,9 +7,9 @@ This workflow is useful for situations when installing and using the Glean CLI i
 
 To configure your Git credentials:
 
-1. Navigate to the [`Settings`](https://glean.io/app/p/settings#access_keys) page using the link in the project dropdown
-2. Click on `Version Control`
-3. Enter your connection settings for the git repository
+1. Navigate to the [`Settings`](https://glean.io/app/p/settings#access_keys) page using the link in the project dropdown.
+2. Click on `Version Control`.
+3. Enter your connection settings for the git repository.
    - To configure your credentials, provide an authorization token _or_ a username and password.
    - We recommend you use an access token to restrict access to just appropriate resources:
      - [Access Tokens in Github](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token)
@@ -17,13 +17,13 @@ To configure your Git credentials:
    - The _Name_ field is optional and will just help users identify in plain language what repository you configured for your project, eg: "engineering data pipeline repo"
    - The default branch will be used as the default for builds, usually "main", "master" or "production"
    - The default path describes the root of your Glean credentials directory within the repo
-4. Click the `🗼Test` button to test your git credentials
-5. Click `Save Credentials`
+4. Click the `🗼Test` button to test your git credentials.
+5. Click `Save Credentials`.
 
 ## Creating builds
 
 After you've configured a Git repository, you can navigate to the [`DataOps`](https://glean.io/app/p/data-ops) page and click `+ New Build` to create a new Build, with the following options:
 
-- `Branch`: A branch or commit identifier from your repository
+- `Branch`: A branch or commit identifier from your repository.
 - `Path`: An optional absolute path to a directory in your repository containing your Glean configuration files.
-- `Type`: The type of build to create. For more details on `Preview` and `Deploy` builds, see [DataOps Overview](/docs/data-ops)
+- `Type`: The type of build to create. For more details on `Preview` and `Deploy` builds, see [DataOps Overview](/docs/data-ops).

--- a/pages/docs/data-ops/grns.mdx
+++ b/pages/docs/data-ops/grns.mdx
@@ -39,13 +39,13 @@ GRNs are case sensitive.
 
 ## Using GRNs
 
-### Linking Existing Resources to DataOps
+### Linking existing resources to DataOps
 
 All resources can be specified with the special `grn` property to link a DataOps
 config to an existing resource. This allows you to move a resource created in
 the Glean web app into DataOps, without recreating it.
 
-### Referencing other Resources
+### Referencing other resources
 
 Anywhere you specify a filepath in a DataOps config, you may instead specify a GRN.
 This allows you to reference resources independently of how you structure your files.

--- a/pages/docs/data-ops/managing-resources-with-code.mdx
+++ b/pages/docs/data-ops/managing-resources-with-code.mdx
@@ -7,11 +7,11 @@ Here is a high-level description of what actually happens during the build proce
 - **Create resources.** For models that you check in that do not currently exist, the model is created from scratch from your configuration file and from the database. This means that the base table and all the columns must still exist in the database for the build to succeed.
 - **Update resources.** If a column is changed, it will be updated in all dependent items (regardless of whether the dependent items were also checked in) - so things like name changes should be correctly reflected.
 - **Clean up resources.** If any columns or models are deleted, all dependent items that relied on that column or model will also be deleted.
-- **Smoke Test.** Once the model is built, a single aggregate analytical query will be run against the database to make sure that data aggregation can still be run against the model.
+- **Smoke test.** Once the model is built, a single aggregate analytical query will be run against the database to make sure that data aggregation can still be run against the model.
 
 If there is an error while deploying a Data Model, the build process will revert to the previous version of that model, and all dependent resources of that model will not be updated.
 
-## Glean Configuration Files
+## Glean configuration files
 
 Glean supports configuration files written in YAML or JSON. A Glean Build will attempt to validate every file in the specified path with a `.yml` or `.json` extension.
 
@@ -35,7 +35,7 @@ An easy way to get started building a configuration file is to export it from an
 - Saved Views: On any Explore page, click the `⋮` in the top-right corner of the chart area, and then click `Export Saved View Config File`.
 - Dashboards: On any Dashboard page, click the `⋮` in the top-right corner, and then click `View DataOps Config File`.
 
-### Migrating Existing Resources into DataOps
+### Migrating existing resources into DataOps
 
 If you have existing content built in the UI and want to move it into DataOps,
 you can specify the `grn` property on the resource. This will cause the config to

--- a/pages/docs/guides/create-retention-curves.mdx
+++ b/pages/docs/guides/create-retention-curves.mdx
@@ -1,6 +1,6 @@
 import { Callout } from "nextra-theme-docs";
 
-# Retention curves
+# Create Retention Curves
 
 [Retention curves](https://www.sequoiacap.com/article/retention) allow you to
 see how many users are still active at a given point in time and compare
@@ -181,10 +181,10 @@ A few notes on the resulting columns:
 1. Make sure you add the Active Users metric specified above.
 2. Select a `pivot table` as your visualization type from the chart dropdown on
    the top left.
-3. Select `cohort` as your rows
-4. Select `month_number` as your columns
+3. Select `cohort` as your rows.
+4. Select `month_number` as your columns.
 5. Click into the `control` tab on the right-hand side and make sure you sort
-   rows by `cohort` descending and sort the columns by `month_number` ascending
+   rows by `cohort` descending and sort the columns by `month_number` ascending.
 6. As the metric, select `Active Users` as the calculation, select
    `Percentage of Row Max` and finally as the Color scale, select
-   `Percentage Color Scale`
+   `Percentage Color Scale`.

--- a/pages/docs/project-management/collections.mdx
+++ b/pages/docs/project-management/collections.mdx
@@ -6,7 +6,7 @@ together to allow your organization to more easily find and share related data.
 You can see all your collections on the [collections page](https://glean.io/app/p/collections).
 From this page, you can also create a new collection.
 
-## Adding Resources to Collections
+## Adding resources to collections
 
 From the collections page, you can add resources to a collection using the
 "add resource" button. You can also reorder items within the collection by
@@ -19,14 +19,14 @@ or creating new ones.
 The same resource can be in multiple collections at once. For example, the
 "Total Revenue" saved view may be in the "OKRs" and "Financial" collections.
 
-## Presentation View
+## Presentation view
 
 Select "Present" within a collection to hop into a view of all the collection's
 contents. This link can be shared with users in your project for a minimal,
 clean view of a group of related data, perfect for a slide-show or other
 presentation.
 
-## Creating Sub-Collections
+## Creating sub-collections
 
 Collections can be nested within each other to allow for fine-grain organization.
 You may have an "OKRs" collection with a subcollection for each quarter, for

--- a/pages/docs/project-management/custom-styles.mdx
+++ b/pages/docs/project-management/custom-styles.mdx
@@ -2,7 +2,7 @@
 
 Custom style settings allow you to control how your Glean project looks and feels.
 
-## Color Palettes
+## Color palettes
 
 Color palettes set the default color for a chart and the colors for [color breakouts](/docs/visualizing-data/breakout)
 

--- a/pages/docs/project-management/datetime-settings.mdx
+++ b/pages/docs/project-management/datetime-settings.mdx
@@ -1,6 +1,6 @@
 import { Callout } from "nextra-theme-docs";
 
-# Project-level datetime settings
+# Datetime Settings
 
 Some datetime-related settings can be customized at the project level.
 

--- a/pages/docs/project-management/demo-projects.mdx
+++ b/pages/docs/project-management/demo-projects.mdx
@@ -2,6 +2,7 @@
 
 Sandbox demo projects are an easy way to use all functionality in Glean with pre-loaded public datasets.
 
+<br />
 <div style={{ position: "relative", paddingBottom: "62.5%", height: 0 }}>
   <iframe
     src="https://www.loom.com/embed/e24c7ede9f4d4262ae19f715f75f45e7?hide_owner=true&hide_share=true&hide_title=true&hideEmbedTopBar=true"
@@ -19,7 +20,7 @@ Sandbox demo projects are an easy way to use all functionality in Glean with pre
   />
 </div>
 
-These projects are great for
+These projects are great for:
 
 - Educational/training sessions where you don't want to share your actual data.
 - Experimentation with new features in Glean without modifying your own resources.

--- a/pages/docs/project-management/partner-projects.mdx
+++ b/pages/docs/project-management/partner-projects.mdx
@@ -1,5 +1,7 @@
 import { Callout } from "nextra-theme-docs";
 
+# Partner Projects
+
 Create Partner Projects to safely share data with external partners without inviting them into your main project.
 
 You may use Glean to analyze data about how your business partners or customers interact with your product. In some cases, you might want to surface these insights back to them on a consistent basis. Perhaps you'd even like to provide them the ability to independently explore their data. This is where Partner Projects come in.

--- a/pages/docs/project-management/single-sign-on.mdx
+++ b/pages/docs/project-management/single-sign-on.mdx
@@ -2,7 +2,7 @@ import { Callout } from "nextra-theme-docs";
 
 # Single Sign-On
 
-Glean supports using an Identity Provider (IdP) such as Okta to control authentication through single sign-on.
+Glean supports using an Identity Provider (IdP) such as Okta to control authentication through single sign-on (SSO).
 It also supports provisioning and deprovisioning Glean users along with managing their custom Glean
 role assignments through SCIM (directory sync). This document describes how to integrate Glean into your IdP.
 
@@ -15,7 +15,7 @@ role assignments through SCIM (directory sync). This document describes how to i
 
 ## Setting up single sign-on
 
-Glean supports the SAML protocol for single sign-on (SSO) authentication. Once you reach out to us to
+Glean supports the SAML protocol for single sign-on authentication. Once you reach out to us to
 initiate setup, we'll provide you with a link that will walk you through the necessary steps to perform in your IdP.
 
 Upon completing this integration, users will no longer be able to log in with their previous Glean authentication method
@@ -63,13 +63,13 @@ overwritten by the IdP user's information. If we one, that Glean user will now b
 email) will be reflected in Glean going forward. If we find no existing user with the given primary email on SCIM initiation, that IdP user will be provisioned
 a new Glean user.
 
-### Managing Users
+### Managing users
 
 When you assign users to Glean in your IdP, Glean will automatically be notified of these changes in real time through SCIM and will create or update the relevant
 Glean user appropriately. You don't need to perform any actions in Glean unless you're attempting to create a new role and assign users to it (see below). In fact,
 creating, editing, and deleting users in Glean is restricted for SSO-enabled projects.
 
-### Managing Roles
+### Managing roles
 
 Creating new Glean roles and editing existing roles must still be done in your Glean project. Glean `Owner`s can do this by default. However, if SSO is enabled for your
 project, they won't be able to assign users to these roles in Glean. This must be done in your IdP by modifying the `roles` custom attribute defined for those users.

--- a/pages/docs/project-management/users-and-permissions.mdx
+++ b/pages/docs/project-management/users-and-permissions.mdx
@@ -21,16 +21,16 @@ of your team to edit data models. See [Data Modeling Best Practices](/docs/data-
 </Callout>
 
 1. Go to the [`People`](https://glean.io/app/p/people) page using the link in
-   the project dropdown
-2. Select `Users`
-3. Select `+ Add User`
-4. Fill out the form and select the submit button: `Add User`
+   the project dropdown.
+2. Click `Users`.
+3. Click `+ Add User`.
+4. Fill out the form and click the submit button: `Add User`
 
    - **Email:** Email to send the invite to. Projects can be setup to only allow
      email addresses on your domain (eg. only emails ending in
      `@yourcompany.com`).
    - **Full Name:** User's display name. They can change this themselves at any time.
-   - **Role:** the user's level (see below)
+   - **Role:** The user's role (see below).
 
 5. The invited user will receive an email with an invite link. The user can then
    either create a username and password or use Google authentication to login.
@@ -49,19 +49,19 @@ There are four roles in Glean with increasing levels of permissions.
 ## Modifying roles
 
 <Callout type="info">
-  **Limitations** - Roles are limited today in Glean to two main functions: 1)
-  governing which actions can be taken such as creating saved views, editing
-  dashboards 2) governing access to data models. If you do not have access to
-  read data from a data model, then saved views for that data model will not
+  **Limitations**— Roles are limited today in Glean to two main functions: 1)
+  governing which actions can be taken such as creating saved views and editing
+  dashboards; and 2) governing access to data models. If you do not have access
+  to read data from a data model, then saved views for that data model will not
   work. Today, it is not possible to remove access from a specific view
   independently from a data model.
 </Callout>
 
 Glean uses role based access control to allow users to do specific actions within Glean. You can assign default roles, configure data access and limit which actions specific users can take inside of Glean.
 
-1. Navigate to the `People` page using the link on the left sidebar
-2. Select `Roles`
-3. Click the pencil `✏️` icon next to the role you want to modify
-4. You can edit the role name and description in the main role page
-5. To edit a permission, again click on the pencil `✏️` icon to edit a permission rule
-6. Here you can modify the permissions and resources associated with the permissions
+1. Navigate to the `People` page using the link on the left sidebar.
+2. Click `Roles`.
+3. Click the pencil `✏️` icon next to the role you want to modify.
+4. You can edit the role name and description in the main role page.
+5. To edit a permission, again click on the pencil `✏️` icon to edit a permission rule.
+6. Here you can modify the permissions and resources associated with the permissions.

--- a/pages/docs/sharing-data-externally/iframe-embedding.mdx
+++ b/pages/docs/sharing-data-externally/iframe-embedding.mdx
@@ -1,8 +1,10 @@
 import { Callout } from "nextra-theme-docs";
 
+# Analytics Embedding
+
 Glean supports embedding Data Models, Saved Views, and Dashboards in external applications via an iframe.
 
-## Embedding a Resource
+## Embedding a resource
 
 To embed a Glean resource, add `viewMode=embed` to the URL parameters of your Data Model, Saved View, or Dashboard URL and set that URL to be the `src` of an `iframe` HTML tag.
 

--- a/pages/docs/sharing-data-externally/public-links.mdx
+++ b/pages/docs/sharing-data-externally/public-links.mdx
@@ -11,7 +11,7 @@ Anyone with the `UPDATE_PUBLIC_SHARING` permission (those with the `Editor` or `
 We ensure that those visiting a public link can neither make any edits to the underlying resource(s) nor can they view any data outside of
 the filters specified by your resource(s).
 
-## Turning on Public Links
+## Turning on public links
 
 1. Open a saved view, dashboard, or collection in Glean.
 2. Click the `Share` dropdown at the top right corner and select the `Share as Link` option.
@@ -24,7 +24,7 @@ the filters specified by your resource(s).
   must create a separate public link for it.
 </Callout>
 
-## Turning off Public Links
+## Turning off public links
 
 To turn off a public link, simply toggle `Public Link` to `OFF` in the `Share as Link` modal.
 

--- a/pages/docs/sharing-data-externally/slack-integration.mdx
+++ b/pages/docs/sharing-data-externally/slack-integration.mdx
@@ -6,28 +6,28 @@ automated reports to keep your team up to date with important metrics.
 
 ## Connect the integration
 
-1. Go to [`Integrations`](https://glean.io/app/p/settings#integrations) section in the `Settings` page
-2. Under the `Slack` subsection, click `Add to Slack`
-3. Click `Allow` on the next page to authorize the Glean app for Slack to access your Slack workspace
-4. Click `Return to Settings` on the next page to return to Glean
+1. Go to [`Integrations`](https://glean.io/app/p/settings#integrations) section in the `Settings` page.
+2. Under the `Slack` subsection, click `Add to Slack`.
+3. Click `Allow` on the next page to authorize the Glean app for Slack to access your Slack workspace.
+4. Click `Return to Settings` on the next page to return to Glean.
 
 ## Sharing to Slack
 
 Once someone in your Glean project has connected the Slack integration, Glean users with appropriate permissions
 can share saved views and dashboards to Slack. By default, this is restricted to `Collaborators`.
 
-1. Open a saved view or dashboard in Glean
-2. Click the `Share` dropdown at the top right corner and select the `Share to Slack` option
-3. In the modal that opens, select the Slack channels you'd like to share to and optionally enter a comment with any context
-4. Click `Send` and your report will appear in Slack within the next minute or so
+1. Open a saved view or dashboard in Glean.
+2. Click the `Share` dropdown at the top right corner and select the `Share to Slack` option.
+3. In the modal that opens, select the Slack channels you'd like to share to and optionally enter a comment with any context.
+4. Click `Send` and your report will appear in Slack within the next minute or so.
 
 ## Creating schedules
 
 To schedule a report, follow steps 1-3 above then continue with the following:
 
-1. Check `Schedule recurring report` at the bottom of the modal
-2. Click `Set Schedule` and enter the schedule's timing along with whether you'd like to skip sending reports that have no data
-3. Click `Schedule` to submit the schedule
+1. Check `Schedule recurring report` at the bottom of the modal.
+2. Click `Set Schedule` and enter the schedule's timing along with whether you'd like to skip sending reports that have no data.
+3. Click `Schedule` to submit the schedule.
 
 ## Support
 


### PR DESCRIPTION
This normalizes how the above docs pages look (spacing, casing, list items, etc.) and tweaks copy where appropriate.